### PR TITLE
chore: update standalone angular to pin cypress 13.13.0 

### DIFF
--- a/angular-standalone/package-lock.json
+++ b/angular-standalone/package-lock.json
@@ -26,7 +26,7 @@
         "@angular/cli": "^18.0.2",
         "@angular/compiler-cli": "^18.0.0",
         "@types/jasmine": "~5.1.0",
-        "cypress": "https://cdn.cypress.io/beta/npm/13.12.0/darwin-arm64/angular-signals-ct-harness-c6cba8b03a7d7d098cdb469919eb674d40277604/cypress.tgz",
+        "cypress": "^13.13.0",
         "jasmine-core": "~5.1.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
@@ -5576,12 +5576,11 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "13.12.0",
-      "resolved": "https://cdn.cypress.io/beta/npm/13.12.0/darwin-arm64/angular-signals-ct-harness-c6cba8b03a7d7d098cdb469919eb674d40277604/cypress.tgz",
-      "integrity": "sha512-ox7E/SzHKX0Yj2Z1pjZ5DyXxgeC/KbiqFdvIYdCFW7QS886z3qYEBo6E5aYHfiRwGXihrySrWIk/v2IUP9wM+w==",
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.0.tgz",
+      "integrity": "sha512-ou/MQUDq4tcDJI2FsPaod2FZpex4kpIK43JJlcBgWrX8WX7R/05ZxGTuxedOuZBfxjZxja+fbijZGyxiLP6CFA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
@@ -5622,7 +5621,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "~0.2.3",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },

--- a/angular-standalone/package.json
+++ b/angular-standalone/package.json
@@ -29,7 +29,7 @@
     "@angular/cli": "^18.0.2",
     "@angular/compiler-cli": "^18.0.0",
     "@types/jasmine": "~5.1.0",
-    "cypress": "https://cdn.cypress.io/beta/npm/13.12.0/darwin-arm64/angular-signals-ct-harness-c6cba8b03a7d7d098cdb469919eb674d40277604/cypress.tgz",
+    "cypress": "^13.13.0",
     "jasmine-core": "~5.1.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",


### PR DESCRIPTION
to avoid having a pined prerelease since cypress `13.13.0` is now available generally