### PR TITLE
chore: update binaries to 14

### DIFF
--- a/angular-standalone/package-lock.json
+++ b/angular-standalone/package-lock.json
@@ -27,7 +27,7 @@
         "@angular/compiler-cli": "^19.0.0",
         "@types/jasmine": "~5.1.0",
         "autoprefixer": "^10.4.20",
-        "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+        "cypress": "^14.0.0",
         "jasmine-core": "~5.4.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",

--- a/angular-standalone/package.json
+++ b/angular-standalone/package.json
@@ -30,7 +30,7 @@
     "@angular/compiler-cli": "^19.0.0",
     "@types/jasmine": "~5.1.0",
     "autoprefixer": "^10.4.20",
-    "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+    "cypress": "^14.0.0",
     "jasmine-core": "~5.4.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -26,7 +26,7 @@
         "@angular/compiler-cli": "^18.2.0",
         "@types/jasmine": "~5.1.0",
         "autoprefixer": "^10.4.20",
-        "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+        "cypress": "^14.0.0",
         "jasmine-core": "~5.2.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",

--- a/angular/package.json
+++ b/angular/package.json
@@ -29,7 +29,7 @@
     "@angular/compiler-cli": "^18.2.0",
     "@types/jasmine": "~5.1.0",
     "autoprefixer": "^10.4.20",
-    "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+    "cypress": "^14.0.0",
     "jasmine-core": "~5.2.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/react-next14-ts/package-lock.json
+++ b/react-next14-ts/package-lock.json
@@ -16,7 +16,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
-        "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+        "cypress": "^14.0.0",
         "eslint": "^8",
         "eslint-config-next": "14.2.16",
         "msw": "^2.6.0",

--- a/react-next14-ts/package.json
+++ b/react-next14-ts/package.json
@@ -18,7 +18,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+    "cypress": "^14.0.0",
     "eslint": "^8",
     "eslint-config-next": "14.2.16",
     "msw": "^2.6.0",

--- a/react-next15-ts/package-lock.json
+++ b/react-next15-ts/package-lock.json
@@ -8,7 +8,7 @@
       "name": "react-next15-ts",
       "version": "0.1.0",
       "dependencies": {
-        "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+        "cypress": "^14.0.0",
         "next": "15.0.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"

--- a/react-next15-ts/package.json
+++ b/react-next15-ts/package.json
@@ -10,7 +10,7 @@
     "cypress:run": "cypress run --component"
   },
   "dependencies": {
-    "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+    "cypress": "^14.0.0",
     "next": "15.0.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/react-vite-ts/package-lock.json
+++ b/react-vite-ts/package-lock.json
@@ -17,7 +17,7 @@
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
-        "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+        "cypress": "^14.0.0",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.14",
         "typescript": "^5.6.3",
@@ -6513,7 +6513,8 @@
       "dev": true
     },
     "cypress": {
-      "version": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+      "version": "14.0.0",
+      "resolved": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
       "integrity": "sha512-m7v9NONPBQbjAremmDXaIJw0v6nz2TOPYLZ04kUkl5JnESvYJiczqLfW4mCtE9MZHHiFrffdp5afdF9I2w2gDg==",
       "dev": true,
       "requires": {

--- a/react-vite-ts/package.json
+++ b/react-vite-ts/package.json
@@ -18,7 +18,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
-    "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+    "cypress": "^14.0.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3",

--- a/react-webpack5-js/package-lock.json
+++ b/react-webpack5-js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+        "cypress": "^14.0.0",
         "msw": "^2.6.7",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"

--- a/react-webpack5-js/package.json
+++ b/react-webpack5-js/package.json
@@ -28,7 +28,7 @@
     "webpack-dev-server": "^5.1.0"
   },
   "dependencies": {
-    "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+    "cypress": "^14.0.0",
     "msw": "^2.6.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/svelte-vite-ts/package-lock.json
+++ b/svelte-vite-ts/package-lock.json
@@ -11,7 +11,7 @@
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "@tsconfig/svelte": "^5.0.4",
         "autoprefixer": "^10.4.20",
-        "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+        "cypress": "^14.0.0",
         "msw": "^2.6.6",
         "svelte": "^5.6.2",
         "svelte-check": "^4.1.0",

--- a/svelte-vite-ts/package.json
+++ b/svelte-vite-ts/package.json
@@ -14,7 +14,7 @@
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@tsconfig/svelte": "^5.0.4",
     "autoprefixer": "^10.4.20",
-    "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+    "cypress": "^14.0.0",
     "msw": "^2.6.6",
     "svelte": "^5.6.2",
     "svelte-check": "^4.1.0",

--- a/svelte-webpack-ts/package-lock.json
+++ b/svelte-webpack-ts/package-lock.json
@@ -13,7 +13,7 @@
         "cross-env": "^7.0.3",
         "css-loader": "^7.1.2",
         "css-minimizer-webpack-plugin": "^4.0.0",
-        "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+        "cypress": "^14.0.0",
         "html-webpack-plugin": "^5.6.3",
         "mini-css-extract-plugin": "^2.9.2",
         "msw": "^2.6.6",

--- a/svelte-webpack-ts/package.json
+++ b/svelte-webpack-ts/package.json
@@ -15,7 +15,7 @@
     "cross-env": "^7.0.3",
     "css-loader": "^7.1.2",
     "css-minimizer-webpack-plugin": "^4.0.0",
-    "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+    "cypress": "^14.0.0",
     "html-webpack-plugin": "^5.6.3",
     "mini-css-extract-plugin": "^2.9.2",
     "msw": "^2.6.6",

--- a/vue3-vite-ts/package-lock.json
+++ b/vue3-vite-ts/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.2.1",
         "autoprefixer": "^10.4.20",
-        "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+        "cypress": "^14.0.0",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.14",
         "typescript": "^5.6.3",
@@ -6248,7 +6248,8 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "cypress": {
-      "version": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+      "version": "14.0.0",
+      "resolved": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
       "integrity": "sha512-m7v9NONPBQbjAremmDXaIJw0v6nz2TOPYLZ04kUkl5JnESvYJiczqLfW4mCtE9MZHHiFrffdp5afdF9I2w2gDg==",
       "dev": true,
       "requires": {

--- a/vue3-vite-ts/package.json
+++ b/vue3-vite-ts/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",
     "autoprefixer": "^10.4.20",
-    "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+    "cypress": "^14.0.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3",

--- a/vue3-webpack-ts/package-lock.json
+++ b/vue3-webpack-ts/package-lock.json
@@ -15,7 +15,7 @@
         "babel-loader": "^9.2.1",
         "core-js": "^3.39.0",
         "css-loader": "^7.1.2",
-        "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+        "cypress": "^14.0.0",
         "html-webpack-plugin": "^5.6.3",
         "msw": "^2.6.2",
         "postcss": "^8.4.47",

--- a/vue3-webpack-ts/package.json
+++ b/vue3-webpack-ts/package.json
@@ -18,7 +18,7 @@
     "babel-loader": "^9.2.1",
     "core-js": "^3.39.0",
     "css-loader": "^7.1.2",
-    "cypress": "https://cdn.cypress.io/beta/npm/14.0.0/darwin-arm64/develop-61f10424edb768447b2a70b7ecc362375ad71e2d/cypress.tgz",
+    "cypress": "^14.0.0",
     "html-webpack-plugin": "^5.6.3",
     "msw": "^2.6.2",
     "postcss": "^8.4.47",


### PR DESCRIPTION
updates the 14 branch to use Cypress 14 published binary, which is currently at the dev tag