### PR TITLE
ci: update to ubuntu 24.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
@@ -49,4 +49,3 @@ jobs:
           wait-on: 'http://localhost:4200'
           working-directory: "${{ matrix.project }}"
           browser: chrome
-


### PR DESCRIPTION
## Situation

The workflow [.github/workflows/main.yml](https://github.com/cypress-io/cypress-component-testing-apps/blob/main/.github/workflows/main.yml) uses the GitHub Actions runner image [ubuntu-22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md).

This is not the latest Ubuntu version. See [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) which is labeled `ubuntu-latest`.

Other active repos, including the [equivalent workflow](https://github.com/cypress-io/component-testing-quickstart-apps/blob/main/.github/workflows/test.yml) in [cypress-io/component-testing-quickstart-apps](https://github.com/cypress-io/component-testing-quickstart-apps/blob/main/.github/workflows/test.yml) repo, have already been migrated to use [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md).

## Change

Update the workflow [.github/workflows/main.yml](https://github.com/cypress-io/cypress-component-testing-apps/blob/main/.github/workflows/main.yml) to use the GitHub Actions runner image [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) - corresponding to `ubuntu-latest`.