### PR TITLE
fix: add TypeScript baseUrl in examples

### DIFF
--- a/angular-standalone/tsconfig.json
+++ b/angular-standalone/tsconfig.json
@@ -3,6 +3,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "strict": true,
     "noImplicitOverride": true,

--- a/angular/tsconfig.json
+++ b/angular/tsconfig.json
@@ -3,6 +3,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "strict": true,
     "noImplicitOverride": true,

--- a/react-next14-ts/tsconfig.json
+++ b/react-next14-ts/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/react-next15-ts/tsconfig.json
+++ b/react-next15-ts/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,

--- a/react-vite-ts/tsconfig.json
+++ b/react-vite-ts/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "target": "ESNext",
     "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],

--- a/vue3-vite-ts/tsconfig.json
+++ b/vue3-vite-ts/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "target": "esnext",
     "useDefineForClassFields": true,
     "module": "esnext",


### PR DESCRIPTION
## Issue

Multiple TypeScript projects output the following warning when Cypress is run:

> Missing baseUrl in compilerOptions. tsconfig-paths will be skipped

See logs of [actions/workflows/main.yml](https://github.com/cypress-io/cypress-component-testing-apps/actions/workflows/main.yml)

- angular
- angular-standalone
- react-next14-ts
- react-next15-ts
- react-vite-ts
- vue3-vite-ts

## Change

Add the following to `tsconfig.json` in the root directory of each of the impacted projects listed above:

```json
  "compilerOptions": {
    "baseUrl": "./",
...
},
```

## Verification

View workflow logs of jobs in [actions/workflows/main.yml](https://github.com/cypress-io/cypress-component-testing-apps/actions/workflows/main.yml) and confirm that the following warning no longer appears:

> Missing baseUrl in compilerOptions. tsconfig-paths will be skipped

## Related

- https://github.com/cypress-io/cypress/issues/15724
